### PR TITLE
Skip checking 'generate' directive implementation on runtime

### DIFF
--- a/schema/fastgql.go
+++ b/schema/fastgql.go
@@ -26,6 +26,7 @@ func (f FastGqlPlugin) MutateConfig(cfg *config.Config) error {
 	cfg.Directives["sqlRelation"] = config.DirectiveConfig{SkipRuntime: true}
 	cfg.Directives["tableName"] = config.DirectiveConfig{SkipRuntime: true}
 	cfg.Directives["generateMutations"] = config.DirectiveConfig{SkipRuntime: true}
+	cfg.Directives["generate"] = config.DirectiveConfig{SkipRuntime: true}
 	return nil
 }
 


### PR DESCRIPTION
Fixes #24 

`@generate` was not registered as a runtime directive which resulted in a query error. 
This change adds skipping `@generate` implementation checking to the config. 