### PR TITLE
Add database entrypoint to example

### DIFF
--- a/example/db.sql
+++ b/example/db.sql
@@ -1,0 +1,33 @@
+create table if not exists "user"
+(
+    id   integer not null
+        primary key,
+    name varchar not null
+);
+
+alter table "user"
+    owner to postgres;
+
+create table if not exists categories
+(
+    id   integer not null
+        primary key,
+    name varchar
+);
+
+alter table categories
+    owner to postgres;
+
+create table if not exists posts
+(
+    id          integer not null
+        primary key,
+    name        varchar,
+    user_id     integer
+        references "user",
+    category_id integer
+        references categories
+);
+
+alter table posts
+    owner to postgres;

--- a/example/docker-compose.yml
+++ b/example/docker-compose.yml
@@ -9,7 +9,10 @@ services:
     networks:
       - postgres
     environment:
+      POSTGRES_DB: main
       POSTGRES_PASSWORD: password
+    volumes:
+      - ./db.sql:/docker-entrypoint-initdb.d/1-db.sql
 
   pgadmin:
     container_name: pgadmin_container


### PR DESCRIPTION
This feature adds creating `main` database with all tables required to run [example](https://github.com/roneli/fastgql/tree/master/example).